### PR TITLE
Made some small changes to the innerHTML pattern

### DIFF
--- a/SinkLogger.py
+++ b/SinkLogger.py
@@ -57,7 +57,7 @@ class BurpExtender(IBurpExtender, IProxyListener, ITab):
 
         # pattern: replacement passed into re.sub()
         self.sinkPatterns = {
-            r'\.innerHTML=([^=])': r'.innerHTML=QF9iYXlvdG9w.innerHTML=\1',
+            r'\.innerHTML(|[ ])=([^=])': r'.innerHTML=QF9iYXlvdG9w.innerHTML=\2',
             r'eval\(([^)])': r'eval(QF9iYXlvdG9w.eval=\1',
             r'document\.write\(([^)])': r'document.write(QF9iYXlvdG9w.write=\1',
             # r'\$\(([^)])': r'$(QF9iYXlvdG9w.jQuery=\1'

--- a/SinkLogger.py
+++ b/SinkLogger.py
@@ -57,7 +57,7 @@ class BurpExtender(IBurpExtender, IProxyListener, ITab):
 
         # pattern: replacement passed into re.sub()
         self.sinkPatterns = {
-            r'\.innerHTML(|[ ])=([^=])': r'.innerHTML=QF9iYXlvdG9w.innerHTML=\2',
+            r'\.innerHTML\s*=([^=])': r'.innerHTML=QF9iYXlvdG9w.innerHTML=\1',
             r'eval\(([^)])': r'eval(QF9iYXlvdG9w.eval=\1',
             r'document\.write\(([^)])': r'document.write(QF9iYXlvdG9w.write=\1',
             # r'\$\(([^)])': r'$(QF9iYXlvdG9w.jQuery=\1'


### PR DESCRIPTION
Currently, the `innerHTML` replace pattern doesn't match something like:

```javascript
x.innerHTML = 123
```

because of the space between `innerHTML` and the equal sign. I tweaked it a bit and was able to get it to match both. I noticed that I was getting a lot more sinks logged in my console after doing this.